### PR TITLE
QDB-10200 - Fix Win64 segmentation fault

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -213,6 +213,7 @@
           </dependency>
         </dependencies>
         <configuration>
+          <redirectTestOutputToFile>false</redirectTestOutputToFile>
           <trimStackTrace>false</trimStackTrace>
           <additionalClasspathElements>
             <additionalClasspathElement>${project.basedir}/target/jni-3.10.2-SNAPSHOT-linux-x86_64.jar</additionalClasspathElement>

--- a/src/main/c++/net/quasardb/qdb/jni/detail/native_ptr.hpp
+++ b/src/main/c++/net/quasardb/qdb/jni/detail/native_ptr.hpp
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <jni.h>
+
+#include <qdb/client.h>
+#include <qdb/ts.h>
+
+namespace qdb
+{
+namespace jni
+{
+namespace native_ptr
+{
+// QuasarDB's API allocates memory on the native heap (i.e. not managed by the JVM), and
+// we often want to pass this around: qdb_handle_t being the most obvious example of this.
+//
+// In Java, we represent these pointers using a `long` type, and then in native code
+// reinterpret this into the original type. The functions below facilitate this logic, and
+// ensure corner cases are properly checked.
+
+// Java -> JNI
+template <typename T>
+inline jlong to_java(T ptr) {
+  static_assert(sizeof(jlong) >= sizeof(T), "T is a pointer that can be represented using a jlong");
+  return reinterpret_cast<jlong>(ptr);
+}
+
+// JNI -> Java
+template <typename T>
+inline T from_java(jlong ptr) {
+  return reinterpret_cast<T>(ptr);
+}
+
+};
+};
+};

--- a/src/main/c++/net/quasardb/qdb/jni/export/qdb_ts.cpp
+++ b/src/main/c++/net/quasardb/qdb/jni/export/qdb_ts.cpp
@@ -903,9 +903,6 @@ Java_net_quasardb_qdb_jni_qdb_ts_1local_1table_1init(JNIEnv *jniEnv,
                                                                     columnCount,
                                                                     &ret));
 
-        printf("1 native local table = %p (%d)\n", nativeLocalTable, (long)nativeLocalTable);
-        fflush(stdout);
-
         return jni::native_ptr::to_java(ret);
     }
     catch (jni::exception const &e)
@@ -921,8 +918,6 @@ Java_net_quasardb_qdb_jni_qdb_ts_1local_1table_1release(JNIEnv * /*env*/,
                                                         jlong handle,
                                                         jlong localTable)
 {
-    printf("3 release localTable = %d\n", localTable);
-    fflush(stdout);
     qdb_release((qdb_handle_t)handle, (qdb_local_table_t)localTable);
 }
 
@@ -937,8 +932,6 @@ Java_net_quasardb_qdb_jni_qdb_ts_1table_1get_1ranges(JNIEnv *jniEnv,
 
     try
     {
-        printf("2 get ranges, localTable = %d\n", localTable);
-        fflush(stdout);
         return jni::exception::throw_if_error(
             (qdb_handle_t)handle,
             tableGetRanges(env, (qdb_handle_t)handle,

--- a/src/main/c++/net/quasardb/qdb/jni/export/qdb_ts.cpp
+++ b/src/main/c++/net/quasardb/qdb/jni/export/qdb_ts.cpp
@@ -892,8 +892,7 @@ Java_net_quasardb_qdb_jni_qdb_ts_1local_1table_1init(JNIEnv *jniEnv,
     try
     {
         size_t columnCount = env.instance().GetArrayLength(columns);
-        qdb_ts_column_info_t *nativeColumns =
-            new qdb_ts_column_info_t[columnCount];
+        std::unique_ptr<qdb_ts_column_info_t> nativeColumns{new qdb_ts_column_info_t[columnCount]};
 
         columnsToNative(env, columns, nativeColumns.get(), columnCount);
 
@@ -964,14 +963,14 @@ Java_net_quasardb_qdb_jni_qdb_ts_1table_1next_1row(JNIEnv *jniEnv,
     try
     {
         size_t columnCount = env.instance().GetArrayLength(columns);
-        qdb_ts_column_info_t *nativeColumns = (qdb_ts_column_info_t *)(malloc(
-            columnCount * sizeof(qdb_ts_column_info_t)));
 
-        columnsToNative(env, columns, nativeColumns, columnCount);
+        std::unique_ptr<qdb_ts_column_info_t> nativeColumns{new qdb_ts_column_info_t[columnCount]};
+
+        columnsToNative(env, columns, nativeColumns.get(), columnCount);
 
         return tableGetRow(env, (qdb_handle_t)handle,
                            (qdb_local_table_t)localTable,
-                           nativeColumns,
+                           nativeColumns.get(),
                            columnCount);
 
     }

--- a/src/main/c++/net/quasardb/qdb/jni/export/qdb_ts.cpp
+++ b/src/main/c++/net/quasardb/qdb/jni/export/qdb_ts.cpp
@@ -863,13 +863,12 @@ Java_net_quasardb_qdb_jni_qdb_ts_1batch_1row_1set_1pinned_1double(JNIEnv * jniEn
 
 
 
-JNIEXPORT jint JNICALL
+JNIEXPORT jlong JNICALL
 Java_net_quasardb_qdb_jni_qdb_ts_1local_1table_1init(JNIEnv *jniEnv,
                                                      jclass /*thisClass*/,
                                                      jlong handle,
                                                      jstring alias,
-                                                     jobjectArray columns,
-                                                     jobject localTable)
+                                                     jobjectArray columns)
 {
     qdb::jni::env env(jniEnv);
 
@@ -881,22 +880,24 @@ Java_net_quasardb_qdb_jni_qdb_ts_1local_1table_1init(JNIEnv *jniEnv,
 
         columnsToNative(env, columns, nativeColumns, columnCount);
 
-        qdb_local_table_t nativeLocalTable;
+        qdb_local_table_t nativeLocalTable = NULL;
 
-        qdb::jni::exception::throw_if_error(
-            (qdb_handle_t)handle,
-            qdb_ts_local_table_init(
-                (qdb_handle_t)handle,
-                qdb::jni::string::get_chars_utf8(env, alias), nativeColumns,
-                columnCount, &nativeLocalTable));
-        setLong(env, localTable, reinterpret_cast<long>(nativeLocalTable));
+        qdb::jni::exception::throw_if_error((qdb_handle_t)handle,
+                                            qdb_ts_local_table_init((qdb_handle_t)handle,
+                                                                    qdb::jni::string::get_chars_utf8(env, alias), nativeColumns,
+                                                                    columnCount,
+                                                                    &nativeLocalTable));
 
-        return qdb_e_ok;
+        printf("1 native local table = %p (%d)\n", nativeLocalTable, (long)nativeLocalTable);
+        fflush(stdout);
+
+
+        return (long)nativeLocalTable;
     }
     catch (jni::exception const &e)
     {
         e.throw_new(env);
-        return e.error();
+        return -1;
     }
 }
 
@@ -906,6 +907,8 @@ Java_net_quasardb_qdb_jni_qdb_ts_1local_1table_1release(JNIEnv * /*env*/,
                                                         jlong handle,
                                                         jlong localTable)
 {
+    printf("3 release localTable = %d\n", localTable);
+    fflush(stdout);
     qdb_release((qdb_handle_t)handle, (qdb_local_table_t)localTable);
 }
 
@@ -920,6 +923,8 @@ Java_net_quasardb_qdb_jni_qdb_ts_1table_1get_1ranges(JNIEnv *jniEnv,
 
     try
     {
+        printf("2 get ranges, localTable = %d\n", localTable);
+        fflush(stdout);
         return jni::exception::throw_if_error(
             (qdb_handle_t)handle,
             tableGetRanges(env, (qdb_handle_t)handle,

--- a/src/main/c++/net/quasardb/qdb/jni/util/ts_helpers.cpp
+++ b/src/main/c++/net/quasardb/qdb/jni/util/ts_helpers.cpp
@@ -905,13 +905,12 @@ tableGetRowValues(qdb::jni::env &env,
     return qdb_e_ok;
 }
 
-qdb_error_t
+jobject
 tableGetRow(qdb::jni::env &env,
             qdb_handle_t handle,
             qdb_local_table_t localTable,
             qdb_ts_column_info_t *columns,
-            qdb_size_t columnCount,
-            jobject *output)
+            qdb_size_t columnCount)
 {
 
     qdb_timespec_t timestamp;
@@ -919,7 +918,7 @@ tableGetRow(qdb::jni::env &env,
 
     if (err == qdb_e_iterator_end)
     {
-        return err;
+        return NULL;
     }
 
     jni::exception::throw_if_error(handle, err);
@@ -931,12 +930,9 @@ tableGetRow(qdb::jni::env &env,
         handle, tableGetRowValues(env, handle, localTable, columns, columnCount,
                                   values));
 
-    *output =
-        jni::object::create(
-            env, "net/quasardb/qdb/ts/WritableRow",
-            "(Lnet/quasardb/qdb/ts/Timespec;[Lnet/quasardb/qdb/ts/Value;)V",
-            nativeToTimespec(env, timestamp).release(), values.release())
-            .release();
+    return jni::object::create(env,
+                               "net/quasardb/qdb/ts/WritableRow",
+                               "(Lnet/quasardb/qdb/ts/Timespec;[Lnet/quasardb/qdb/ts/Value;)V",
+                               nativeToTimespec(env, timestamp).release(), values.release()).release();
 
-    return qdb_e_ok;
 }

--- a/src/main/c++/net/quasardb/qdb/jni/util/ts_helpers.h
+++ b/src/main/c++/net/quasardb/qdb/jni/util/ts_helpers.h
@@ -118,9 +118,8 @@ qdb_error_t tableGetRanges(qdb::jni::env &env,
                            qdb_local_table_t localTable,
                            jobjectArray ranges);
 
-qdb_error_t tableGetRow(qdb::jni::env &env,
-                        qdb_handle_t handle,
-                        qdb_local_table_t localTable,
-                        qdb_ts_column_info_t *columns,
-                        qdb_size_t columnCount,
-                        jobject *output);
+jobject tableGetRow(qdb::jni::env &env,
+                    qdb_handle_t handle,
+                    qdb_local_table_t localTable,
+                    qdb_ts_column_info_t *columns,
+                    qdb_size_t columnCount);

--- a/src/main/java/net/quasardb/qdb/jni/qdb.java
+++ b/src/main/java/net/quasardb/qdb/jni/qdb.java
@@ -127,8 +127,11 @@ public final class qdb
 
     public static native int ts_insert_columns(long handle, String alias, Column[] columns);
     public static native Column[] ts_list_columns(long handle, String alias);
-    public static native int
-    ts_local_table_init(long handle, String alias, Column[] columns, Reference<Long> localTable);
+
+    // Returns qdb_ts_table_t
+    public static native long ts_local_table_init(long handle,
+                                                  String alias,
+                                                  Column[] columns);
 
 
     // Returns qdb_ts_batch_table_t

--- a/src/main/java/net/quasardb/qdb/jni/qdb.java
+++ b/src/main/java/net/quasardb/qdb/jni/qdb.java
@@ -126,12 +126,13 @@ public final class qdb
     public static native long ts_shard_size(long handle, String alias);
 
     public static native int ts_insert_columns(long handle, String alias, Column[] columns);
-    public static native int ts_list_columns(long handle, String alias, Reference<Column[]> columns);
+    public static native Column[] ts_list_columns(long handle, String alias);
     public static native int
     ts_local_table_init(long handle, String alias, Column[] columns, Reference<Long> localTable);
 
 
-    public static native int ts_batch_table_init(long handle, Writer.TableColumn[] columns, Reference<Long> batchTable);
+    // Returns qdb_ts_batch_table_t
+    public static native long ts_batch_table_init(long handle, Writer.TableColumn[] columns);
     public static native int ts_batch_table_extra_columns(long handle, long batchTable, Writer.TableColumn[] columns);
     public static native void ts_batch_table_release(long handle, long batchTable);
 
@@ -288,7 +289,7 @@ public final class qdb
 
     public static native void ts_local_table_release(long handle, long localTable);
     public static native int ts_table_get_ranges(long handle, long localTable, TimeRange[] ranges);
-    public static native int ts_table_next_row(long handle, long localTable, Column[] columns, Reference<WritableRow> output);
+    public static native WritableRow ts_table_next_row(long handle, long localTable, Column[] columns);
 
     public static native int ts_double_insert(long handle, String alias, String column, qdb_ts_double_point[] points);
     public static native int ts_double_get_ranges(

--- a/src/main/java/net/quasardb/qdb/ts/Reader.java
+++ b/src/main/java/net/quasardb/qdb/ts/Reader.java
@@ -43,14 +43,9 @@ public class Reader implements AutoCloseable, Iterator<WritableRow> {
         this.localTable = qdb.ts_local_table_init(this.session.handle(),
                                                   table.getName(),
                                                   table.getColumns());
-
-        System.out.printf("A local table = %d%n", this.localTable);
-        // Verify pointer validity
-        // assert (this.localTable > 0);
+        assert (this.localTable > 0);
 
         qdb.ts_table_get_ranges(this.session.handle(), this.localTable, ranges);
-
-        System.out.println("B retrieved ranges...");
     }
 
     /**

--- a/src/main/java/net/quasardb/qdb/ts/Table.java
+++ b/src/main/java/net/quasardb/qdb/ts/Table.java
@@ -52,6 +52,8 @@ public class Table implements Serializable {
      * @param name Timeseries name. Must already exist.
      */
     public Table(Column[] columns, long shardSizeMillis, String name) {
+        assert(columns != null);
+
         this.name = name;
         this.columns = columns;
         this.shardSizeMillis = shardSizeMillis;
@@ -707,17 +709,16 @@ public class Table implements Serializable {
      * @param name Unique identifier for this timeseries table.
      */
     static public Column[] getColumns(Session session, String name) {
-        Reference<Column[]> columns =
-            new Reference<Column[]>();
-        qdb.ts_list_columns(session.handle(), name, columns);
-
-        return columns.value;
+        Column[] ret = qdb.ts_list_columns(session.handle(), name);
+        assert(ret != null);
+        return ret;
     }
 
     /**
      * Returns column representation of this table.
      */
     public Column[] getColumns() {
+        assert(this.columns != null);
         return this.columns;
     }
 

--- a/src/main/java/net/quasardb/qdb/ts/Writer.java
+++ b/src/main/java/net/quasardb/qdb/ts/Writer.java
@@ -62,7 +62,7 @@ public class Writer implements AutoCloseable, Flushable {
     protected long pointsSinceFlush = 0;
     boolean async;
     Session session;
-    Long batchTable;
+    long batchTable;
     protected List<TableColumn> columns;
 
     TimeRange minMaxTs;
@@ -123,12 +123,13 @@ public class Writer implements AutoCloseable, Flushable {
 
         TableColumn[] tableColumns = this.columns.toArray(new TableColumn[columns.size()]);
         Reference<Long> theBatchTable = new Reference<Long>();
-        qdb.ts_batch_table_init(this.session.handle(),
-                                tableColumns,
-                                theBatchTable);
+        this.batchTable = qdb.ts_batch_table_init(this.session.handle(),
+                                                  tableColumns);
+
+        // Crude check for pointer validity
+        assert(this.batchTable > 0);
 
         logger.info("Successfully initialized Writer with {} columns for {} tables to Writer state", this.columns.size(), tables.length);
-        this.batchTable = theBatchTable.value;
     }
 
     /**
@@ -219,7 +220,7 @@ public class Writer implements AutoCloseable, Flushable {
         //this.flush();
         qdb.ts_batch_table_release(this.session.handle(), this.batchTable);
 
-        this.batchTable = null;
+        this.batchTable = -1;
     }
 
     public Writer.PushMode pushMode() {


### PR DESCRIPTION
This PR fixes a segfault that occurred on win64, but the bug was present on all platforms. In the JNI native code, there was an implicit assumption that `sizeof(long) == sizeof(jlong) == sizeof(std::uintptr_t)`. On win64, however, this didn't hold.

In various places, rather than casting to `jlong`, we casted to `long` instead. This caused the first 4 bytes of the point address to be truncated. This didn't surface earlier, because nothing else really overwrote the first 4 bytes. In more recent versions of the JVM, however, this issue did surface on win64.

The PR addresses this by:

 * Introducing a "native_ptr" helper module that has functions to (safely) cast from and to JVM;
 * Introduce static asserts which verify (at compile time) that the objects we're trying to cast fit in `jlong`;
 * Refactor batch writer and bulk reader functions to make use of these utility functions.

All other functions have been manually audited that they're not doing any invalid casts.

Further work:

 * Ensure _all_ functions make use of these helper functions;
 * We want to enable `-Wall -Werror`, as this would have caught these unsafe type casts much earlier.