### PR TITLE
QDB-14243 - Fix java api

### DIFF
--- a/src/test/java/net/quasardb/qdb/SessionOptionsTest.java
+++ b/src/test/java/net/quasardb/qdb/SessionOptionsTest.java
@@ -42,17 +42,6 @@ public class SessionOptionsTest {
         assertTrue(s.getClientMaxParallelism() > 0);
     }
 
-
-    @Test
-    public void canSetClientMaxParallelism() {
-        Session s = TestUtils.createSession();
-
-        long old = s.getClientMaxParallelism();
-        s.setClientMaxParallelism(old * 2);
-
-        assertEquals(s.getClientMaxParallelism(), old * 2);
-    }
-
     @Test
     public void canSetSoftMemoryLimit() {
         Session s = TestUtils.createSession();


### PR DESCRIPTION
Fixes java api:

 * batch writer / reader use char const * instead of qdb_string_t
 * parallelism can now not be set after client initialization