### PR TITLE
Fix build after QDB-16938

### DIFF
--- a/src/test/java/net/quasardb/qdb/PerformanceTraceTest.java
+++ b/src/test/java/net/quasardb/qdb/PerformanceTraceTest.java
@@ -146,7 +146,7 @@ public class PerformanceTraceTest {
 
         w.flush();
 
-        Collection<PerformanceTrace.Trace> res5 = PerformanceTrace.pop(s);\
+        Collection<PerformanceTrace.Trace> res5 = PerformanceTrace.pop(s);
         System.out.println("res5: " + res5);
         assertEquals(2, res5.size());
     }

--- a/src/test/java/net/quasardb/qdb/PerformanceTraceTest.java
+++ b/src/test/java/net/quasardb/qdb/PerformanceTraceTest.java
@@ -126,8 +126,6 @@ public class PerformanceTraceTest {
 
         Collection<PerformanceTrace.Trace> res2 = PerformanceTrace.pop(s);
 
-        System.out.println("res2: " + res2);
-
         assertEquals(0, res1.size());
         assertEquals(3, res2.size());
 
@@ -147,7 +145,6 @@ public class PerformanceTraceTest {
         w.flush();
 
         Collection<PerformanceTrace.Trace> res5 = PerformanceTrace.pop(s);
-        System.out.println("res5: " + res5);
         assertEquals(2, res5.size());
     }
 

--- a/src/test/java/net/quasardb/qdb/PerformanceTraceTest.java
+++ b/src/test/java/net/quasardb/qdb/PerformanceTraceTest.java
@@ -70,7 +70,7 @@ public class PerformanceTraceTest {
         Table t = TestUtils.createTable(s, columns);
 
         Collection<PerformanceTrace.Trace> res = PerformanceTrace.get(s);
-        assertEquals(2, res.size());
+        assertEquals(3, res.size());
 
         for (PerformanceTrace.Trace trace : res) {
             assertTrue(trace.measurements.length > 1);
@@ -96,7 +96,7 @@ public class PerformanceTraceTest {
         PerformanceTrace.clear(s);
         Collection<PerformanceTrace.Trace> res2 = PerformanceTrace.get(s);
 
-        assertEquals(2, res1.size());
+        assertEquals(3, res1.size());
         assertEquals(0, res2.size());
     }
 
@@ -110,7 +110,10 @@ public class PerformanceTraceTest {
         Collection<PerformanceTrace.Trace> res1 = PerformanceTrace.pop(s);
         Collection<PerformanceTrace.Trace> res2 = PerformanceTrace.get(s);
 
-        assertEquals(2, res1.size());
+        System.out.println("res1: " + res1);
+        System.out.println("res2: " + res2);
+
+        assertEquals(3, res1.size());
         assertEquals(0, res2.size());
     }
 
@@ -127,7 +130,7 @@ public class PerformanceTraceTest {
         Collection<PerformanceTrace.Trace> res2 = PerformanceTrace.pop(s);
 
         assertEquals(0, res1.size());
-        assertEquals(2, res2.size());
+        assertEquals(3, res2.size());
 
         Writer w = Writer.builder(s).build();
 
@@ -145,7 +148,7 @@ public class PerformanceTraceTest {
         w.flush();
 
         Collection<PerformanceTrace.Trace> res5 = PerformanceTrace.pop(s);
-        assertEquals(2, res5.size());
+        assertEquals(3, res5.size());
     }
 
     @Test

--- a/src/test/java/net/quasardb/qdb/PerformanceTraceTest.java
+++ b/src/test/java/net/quasardb/qdb/PerformanceTraceTest.java
@@ -110,9 +110,6 @@ public class PerformanceTraceTest {
         Collection<PerformanceTrace.Trace> res1 = PerformanceTrace.pop(s);
         Collection<PerformanceTrace.Trace> res2 = PerformanceTrace.get(s);
 
-        System.out.println("res1: " + res1);
-        System.out.println("res2: " + res2);
-
         assertEquals(3, res1.size());
         assertEquals(0, res2.size());
     }
@@ -128,6 +125,8 @@ public class PerformanceTraceTest {
         Table t = TestUtils.createTable(s, columns);
 
         Collection<PerformanceTrace.Trace> res2 = PerformanceTrace.pop(s);
+
+        System.out.println("res2: " + res2);
 
         assertEquals(0, res1.size());
         assertEquals(3, res2.size());
@@ -147,8 +146,9 @@ public class PerformanceTraceTest {
 
         w.flush();
 
-        Collection<PerformanceTrace.Trace> res5 = PerformanceTrace.pop(s);
-        assertEquals(3, res5.size());
+        Collection<PerformanceTrace.Trace> res5 = PerformanceTrace.pop(s);\
+        System.out.println("res5: " + res5);
+        assertEquals(2, res5.size());
     }
 
     @Test


### PR DESCRIPTION
There is now an extra trace after creating table

Before we had two traces: `ts.create_root`, `ts.get_columns`
Now we have three traces: `ts.create_root`, `ts.get_columns`, `ts.get_columns`